### PR TITLE
Correct readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ gem 'snaky_camel'
 2. Add this line **as the last config** to `config/application.rb`:
 
 ```ruby
-config.middleware.use "SnakyCamel::Middleware"
+config.middleware.use SnakyCamel::Middleware
 ```
 
 ## Usage


### PR DESCRIPTION
Putting `SnakeyCamel::Middleware` in quotes doesn't work

I was getting 
``` 
/usr/local/bundle/gems/actionpack-7.0.2.3/lib/action_dispatch/middleware/stack.rb:37:in `build': undefined method `new' for "SnakyCamel::Middleware":String (NoMethodError)
```
until I switched `config.middleware.use "SnakyCamel::Middleware"` to `config.middleware.use SnakyCamel::Middleware`